### PR TITLE
Adicionar seção “Deputados Seguidos” no perfil do usuário e botão de seguir/deixar de seguir deputados

### DIFF
--- a/frontend/src/components/FollowDeputadoCard/index.jsx
+++ b/frontend/src/components/FollowDeputadoCard/index.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import {
+  CardContainer,
+  FotoArea,
+  InfoArea,
+  DespesasArea,
+  TotalArea
+} from "./styles";
+
+import { useNavigate } from "react-router-dom";
+import { formatarDataBR } from "../../utils/formatarDataBR";
+import { calcularIdade } from "../../utils/calcularIdade";
+
+export function FollowDeputadoCard({ deputado, despesasPorAno, totalGasto}) {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(`/deputados/${deputado.id}`);
+  };
+
+  return (
+    <CardContainer onClick={handleClick}>
+      <FotoArea>
+        <img src={deputado.url_foto} alt={`Foto de ${deputado.nome}`} />
+      </FotoArea>
+      <InfoArea>
+        <b>{deputado.nome}</b>
+        <div><b>Nascimento:</b> {formatarDataBR(deputado.data_nascimento)} ({calcularIdade(deputado.data_nascimento)} anos)</div>
+        <div><b>Partido:</b> {deputado.partido}</div>
+        <div><b>Estado:</b> {deputado.sigla_uf}</div>
+        <div><b>E-mail:</b> {deputado.email}</div>
+      </InfoArea>
+      <DespesasArea>
+        {Object.entries(despesasPorAno).map(([ano, valor]) => (
+          <div key={ano}>{ano}: R$ {valor.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</div>
+        ))}
+      </DespesasArea>
+      <TotalArea>
+        <b>Total Gasto</b>
+        <div>R$ {totalGasto.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</div>
+      </TotalArea>
+    </CardContainer>
+  );
+}

--- a/frontend/src/components/FollowDeputadoCard/index.spec.jsx
+++ b/frontend/src/components/FollowDeputadoCard/index.spec.jsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FollowDeputadoCard } from "./index";
+
+jest.mock("react-router-dom", () => ({
+	useNavigate: () => jest.fn()
+}));
+
+jest.mock("../../utils/formatarDataBR", () => ({
+	formatarDataBR: jest.fn((date) => date ? "01/01/1980" : "Não Informado")
+}));
+
+jest.mock("../../utils/calcularIdade", () => ({
+	calcularIdade: jest.fn((date) => date ? 45 : "Não Informado")
+}));
+
+const deputadoMock = {
+	id: 123,
+	url_foto: "https://foto.com/foto.jpg",
+	nome: "Fulano de Tal",
+	partido: "ABC",
+	sigla_uf: "PE",
+	escolaridade: "Superior Completo",
+	data_nascimento: "1980-01-01",
+	email: "fulano@camara.leg.br"
+};
+
+const despesasMock = {
+	2023: 10000.5,
+	2024: 20000.75
+};
+
+describe("FollowDeputadoCard", () => {
+	it("renderiza todos os dados do deputado", () => {
+		render(
+			<FollowDeputadoCard deputado={deputadoMock} despesasPorAno={despesasMock} totalGasto={30001.25} />
+		);
+		expect(screen.getByText("Fulano de Tal")).toBeInTheDocument();
+		expect(screen.getByText(/Nascimento:/)).toBeInTheDocument();
+		expect(screen.getByText(/01\/01\/1980/)).toBeInTheDocument();
+		expect(screen.getByText(/45 anos/)).toBeInTheDocument();
+		expect(screen.getByText(/Partido:/)).toBeInTheDocument();
+		expect(screen.getByText("ABC")).toBeInTheDocument();
+		expect(screen.getByText(/Estado:/)).toBeInTheDocument();
+		expect(screen.getByText("PE")).toBeInTheDocument();
+		expect(screen.getByText(/E-mail:/)).toBeInTheDocument();
+		expect(screen.getByText("fulano@camara.leg.br")).toBeInTheDocument();
+		expect(screen.getByText(/2023:/)).toBeInTheDocument();
+		expect(screen.getByText(/2024:/)).toBeInTheDocument();
+		expect(screen.getByText(/Total Gasto/)).toBeInTheDocument();
+		expect(screen.getByText("R$ 30.001,25")).toBeInTheDocument();
+		expect(screen.getByRole("img")).toHaveAttribute("src", deputadoMock.url_foto);
+	});
+
+		it("renderiza corretamente quando dados estão ausentes", () => {
+			render(
+				<FollowDeputadoCard deputado={{}} despesasPorAno={{}} totalGasto={0} />
+			);
+			// Busca flexível por 'Não Informado' em múltiplos elementos
+			expect(screen.getAllByText((content) => content.includes("Não Informado"))).not.toHaveLength(0);
+			expect(screen.getByText("R$ 0,00")).toBeInTheDocument();
+		});
+
+	it("navega ao clicar no card", () => {
+		const mockNavigate = jest.fn();
+		// eslint-disable-next-line no-undef
+		jest.spyOn(require("react-router-dom"), "useNavigate").mockReturnValue(mockNavigate);
+		render(
+			<FollowDeputadoCard deputado={deputadoMock} despesasPorAno={despesasMock} totalGasto={30001.25} />
+		);
+		fireEvent.click(screen.getByRole("img"));
+		// O clique no CardContainer deve chamar navigate
+		// Como o CardContainer envolve tudo, pode clicar em qualquer área
+		fireEvent.click(screen.getByText("Fulano de Tal"));
+		expect(mockNavigate).toHaveBeenCalledWith("/deputados/123");
+	});
+
+	it("renderiza despesas por ano corretamente", () => {
+		render(
+			<FollowDeputadoCard deputado={deputadoMock} despesasPorAno={despesasMock} totalGasto={30001.25} />
+		);
+		expect(screen.getByText("2023: R$ 10.000,50")).toBeInTheDocument();
+		expect(screen.getByText("2024: R$ 20.000,75")).toBeInTheDocument();
+	});
+});

--- a/frontend/src/components/FollowDeputadoCard/styles.js
+++ b/frontend/src/components/FollowDeputadoCard/styles.js
@@ -1,0 +1,75 @@
+import styled from "styled-components";
+import theme from "../../styles/theme";
+
+export const CardContainer = styled.div`
+  display: flex;
+  align-items: center;
+  background: ${theme.COLORS.PRIMARY};
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  padding: 1rem;
+  height: 10rem;
+  transition: 0.3s;
+
+  &:hover {
+    filter: brightness(0.9);
+    cursor: pointer;
+    scale: 1.02;
+  }
+
+`;
+
+export const FotoArea = styled.div`
+  height: 80%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 4px;
+  }
+`;
+
+export const InfoArea = styled.div`
+  flex: 2;
+  padding: 16px 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  font-size: 0.875rem;
+  color: #fff;
+  b {
+    font-size: 0.875rem;
+  }
+`;
+
+export const DespesasArea = styled.div`
+  flex: 1;
+  padding: 16px 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border-left: 1px solid #fff;
+  border-right: 1px solid #fff;
+  font-size: 1rem;
+  color: #fff;
+`;
+
+export const TotalArea = styled.div`
+  flex: 1;
+  padding: 16px 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.25rem;
+  color: #fff;
+  b {
+    font-size: 1rem;
+    color: #fff;
+  }
+`;

--- a/frontend/src/hooks/useDeputadoDetails.js
+++ b/frontend/src/hooks/useDeputadoDetails.js
@@ -11,10 +11,14 @@ export function useDeputadoDetais(deputadoid) {
     const [filtros, setFiltros] = useState({});
     const [tipos, setTipos] = useState([]);
     const [estados, setEstados] = useState([]);
+    const [isFollowing, setIsFollowing] = useState(deputado.isFollowing || false);
 
     useEffect(() => {
         getDeputadosById(deputadoid)
-            .then(setDeputado)
+            .then(deputado => {
+                setDeputado(deputado);
+                setIsFollowing(deputado.isFollowing || false);
+            })
             .catch(() => toast.error("Erro ao buscar detalhes do deputado"));
     }, [deputadoid]);
 
@@ -41,5 +45,5 @@ export function useDeputadoDetais(deputadoid) {
         if (deputadoid) fetchReferencias();
     }, [deputadoid]);
 
-    return { deputado, despesas, totalPages, page, setPage, filtros, setFiltros, tipos, estados };
+    return { deputado, despesas, totalPages, page, setPage, filtros, setFiltros, tipos, estados, isFollowing, setIsFollowing };
 }

--- a/frontend/src/pages/DeputadosDetails/DeputadoSidebar.jsx
+++ b/frontend/src/pages/DeputadosDetails/DeputadoSidebar.jsx
@@ -4,7 +4,8 @@ import {FiFlag, FiMapPin, FiBookOpen, FiCalendar} from "react-icons/fi";
 import { calcularIdade } from "../../utils/calcularIdade";
 import { formatarDataBR } from "../../utils/formatarDataBR";
 
-export function DeputadoSidebar({ deputado, onBack }) {
+export function DeputadoSidebar({ deputado, onBack, isFollowing, onFollow }) {
+
   return (
     <Sidebar>
       <BackButton onClick={onBack}>← Voltar</BackButton>
@@ -16,7 +17,7 @@ export function DeputadoSidebar({ deputado, onBack }) {
         <InfoItem><FiBookOpen /> {deputado.escolaridade || "Não Informado"}</InfoItem>
         <InfoItem><FiCalendar /> {`${formatarDataBR(deputado.data_nascimento || "Não Informado")} - (${calcularIdade(deputado.data_nascimento)})`}</InfoItem>
       </InfoList>
-      <Button>{"★ Remover dos Favoritos"}</Button>
+      <Button onClick={onFollow}>{isFollowing ? "★ Deixar de Seguir" : "☆ Seguir Deputado"}</Button>
     </Sidebar>
   );
 }

--- a/frontend/src/pages/DeputadosDetails/DeputadoSidebar.spec.jsx
+++ b/frontend/src/pages/DeputadosDetails/DeputadoSidebar.spec.jsx
@@ -13,13 +13,13 @@ const deputadoMock = {
 
 describe("DeputadoSidebar", () => {
   it("renderiza todos os dados do deputado", () => {
-    render(<DeputadoSidebar deputado={deputadoMock} onBack={() => {}} />);
+    render(<DeputadoSidebar deputado={deputadoMock} onBack={() => {}} isFollowing={true} />);
     expect(screen.getByText("Fulano de Tal")).toBeInTheDocument();
     expect(screen.getByText("ABC")).toBeInTheDocument();
     expect(screen.getByText("PE")).toBeInTheDocument();
     expect(screen.getByText("Superior Completo")).toBeInTheDocument();
     expect(screen.getByRole("img")).toHaveAttribute("src", deputadoMock.url_foto);
-    expect(screen.getByText(/Remover dos Favoritos/)).toBeInTheDocument();
+    expect(screen.getByText(/Deixar de Seguir/)).toBeInTheDocument();
     expect(screen.getByText("← Voltar")).toBeInTheDocument();
   });
 
@@ -39,8 +39,8 @@ describe("DeputadoSidebar", () => {
     expect(onBack).toHaveBeenCalled();
   });
 
-  it("renderiza botão de favoritos", () => {
-    render(<DeputadoSidebar deputado={deputadoMock} onBack={() => {}} />);
-    expect(screen.getByText(/Remover dos Favoritos/)).toBeInTheDocument();
+  it("renderiza botão de favoritos quando isFollowing é true", () => {
+    render(<DeputadoSidebar deputado={deputadoMock} onBack={() => {}} isFollowing={true} />);
+    expect(screen.getByText(/Deixar de Seguir/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/DeputadosDetails/index.jsx
+++ b/frontend/src/pages/DeputadosDetails/index.jsx
@@ -4,15 +4,29 @@ import { useDeputadoDetais } from "../../hooks/useDeputadoDetails";
 import { DeputadoSidebar } from "./DeputadoSidebar";
 import { DeputadoContato } from "./DeputadoContato";
 import { DeputadoDespesas } from "./DeputadoDespesas";
+import { api } from "../../services/api";
+import { toast } from "react-toastify";
 
 export function DeputadosDetails() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { deputado, despesas, totalPages, page, setPage, filtros, setFiltros, tipos, estados } = useDeputadoDetais(id);
+  const { deputado, despesas, totalPages, page, setPage, filtros, setFiltros, tipos, estados, isFollowing, setIsFollowing } = useDeputadoDetais(id);
+
+  function handleFollow() {
+	if(isFollowing){
+		api.delete(`/follows/${id}`)
+		.then(() => setIsFollowing(false))
+		.catch(() => toast.error("Erro ao deixar de seguir o deputado"));
+	} else {
+		api.post(`/follows/${id}`)
+		.then(() => setIsFollowing(true))
+		.catch(() => toast.error("Erro ao seguir o deputado"));
+	}
+  }
 
   return (
 	<Container>
-	  <DeputadoSidebar deputado={deputado} onBack={() => navigate(-1)} />
+	  <DeputadoSidebar deputado={deputado} onBack={() => navigate(-1)} onFollow={handleFollow} isFollowing={isFollowing} />
 	  <MainContent>
 		<DeputadoContato deputado={deputado} />
 		<DeputadoDespesas

--- a/frontend/src/pages/Follows/index.jsx
+++ b/frontend/src/pages/Follows/index.jsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from "react";
+import { SideBar } from "../../components/SideBar";
+import { FollowDeputadoCard } from "../../components/FollowDeputadoCard";
+import { Container, Content, GridDeputados } from "./styles";
+import { api } from "../../services/api";
+import { toast } from "react-toastify";
+
+export function Follows() {
+  const [deputadosSeguidos, setDeputadosSeguidos] = useState([]);
+
+  async function fetchSeguidos() {
+    try {
+      const response = await api.get("/follows");
+      setDeputadosSeguidos(Array.isArray(response.data) ? response.data : []);
+    } catch {
+      toast.error("Erro ao buscar deputados seguidos");
+    }
+  }
+
+  useEffect(() => {
+    fetchSeguidos();
+  }, []);
+
+  return (
+    <Container>
+      <SideBar />
+      <Content>
+        <h1>Deputados Seguidos</h1>
+        <GridDeputados>
+          {deputadosSeguidos.length > 0 ? (
+            deputadosSeguidos.map((item) => (
+              <FollowDeputadoCard
+                key={item.deputado?.id}
+                deputado={item.deputado}
+                despesasPorAno={item.despesasPorAno}
+                totalGasto={item.totalGasto}
+                onCli
+              />
+            ))
+          ) : (
+            <p>Nenhum deputado seguido.</p>
+          )}
+        </GridDeputados>
+      </Content>
+    </Container>
+  );
+}

--- a/frontend/src/pages/Follows/styles.js
+++ b/frontend/src/pages/Follows/styles.js
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  min-height: 100vh;
+  background: white;
+  h1 {
+    font-size: 2rem;
+    font-weight: bold;
+    text-align: center;
+    margin-bottom: 1.5rem;
+  }
+
+  height: 100vh; 
+`;
+
+export const Content = styled.div`
+  flex: 1;
+  padding: 2rem 3rem;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+`;
+
+export const GridDeputados = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 16px;
+`;

--- a/frontend/src/routes/app.routes.jsx
+++ b/frontend/src/routes/app.routes.jsx
@@ -12,6 +12,7 @@ export function AppRoutes() {
         <Route path="/deputados/:id" element={<DeputadosDetails />} />
         <Route path="*" element={<NotFound />} />
         <Route path="/404" element={<NotFound />} />
+        <Route path="/follows" element={<Follows />} />
         <Route path="/profile" element={<Profile />} />
     </Routes>
   );


### PR DESCRIPTION
## **Pull Request:** Adicionar seção “Deputados Seguidos” no perfil do usuário e botão de seguir/deixar de seguir deputados

### 🎯 **Objetivo**
Implementar a listagem de deputados seguidos pelo usuário no perfil, com possibilidade de deixar de seguir diretamente, além da funcionalidade de seguir/deixar de seguir nas páginas de detalhes dos deputados.

### 🧩 **Requisitos atendidos**

**Seção “Deputados Seguidos” no perfil**
* Rota `/seguidos` criada no frontend.
* Consumo do endpoint `GET /follows/seguidos` para buscar deputados seguidos.
* Renderização de cards resumidos contendo:
  * Nome parlamentar
  * Partido/UF
  * Foto
  * Resumo de gastos
* Botão “Deixar de seguir” embutido no card.
* Mensagem exibida quando o usuário não segue nenhum deputado:
  > “Você ainda não está seguindo nenhum deputado.”

**Funcionalidade de seguir/deixar de seguir deputados**

* Botão dinâmico alternando entre “Seguir” e “Seguindo” com feedback visual.
* Integração com API:
  * `POST /follows/:idDeputado`
  * `DELETE /follows/:idDeputado`
* Criação do componente `FollowDeputadoCard` com estilização consistente.
* Adição do estado de acompanhamento no hook `useDeputadoDetails`.

### 📍 **Critérios de Aceitação**

* Usuário pode seguir/deixar de seguir deputados a partir da página de detalhes.
* Página `/seguidos` exibe corretamente a lista de deputados seguidos.
* Botão “Deixar de seguir” funcional diretamente nos cards.
* Mensagem de “nenhum deputado seguido” exibida corretamente quando aplicável.
* Estilização e feedback visual alinhados ao padrão da aplicação.