### PR TITLE
Implementa página de Ranking de Gastos Parlamentares com filtros e visualizações

### DIFF
--- a/frontend/src/components/RankingFilters/index.jsx
+++ b/frontend/src/components/RankingFilters/index.jsx
@@ -1,0 +1,54 @@
+import { Filtros, FiltroLabel, FiltroInput, FiltroSelect } from "./styles";
+
+const currentYear = new Date().getFullYear();
+const currentMonth = new Date().getMonth() + 1;
+
+export function RankingFilters({ limit, setLimit, uf, setUf, partido, setPartido, mes, setMes, ano, setAno, ordem, setOrdem, estados = [], partidos = [] }) {
+  return (
+    <Filtros>
+      <FiltroLabel>Limite:</FiltroLabel>
+      <FiltroSelect value={limit} onChange={e => setLimit(Number(e.target.value))}>
+        {[10, 15, 20, 25, 30, 40, 50].map(v => (
+          <option key={v} value={v}>{v}</option>
+        ))}
+      </FiltroSelect>
+      <FiltroLabel>UF:</FiltroLabel>
+      <FiltroSelect value={uf} onChange={e => setUf(e.target.value)}>
+        <option value="">Todos</option>
+        {estados.map(ufOpt => (
+          <option key={ufOpt} value={ufOpt}>{ufOpt}</option>
+        ))}
+      </FiltroSelect>
+      <FiltroLabel>Partido:</FiltroLabel>
+      <FiltroSelect value={partido} onChange={e => setPartido(e.target.value)}>
+        <option value="">Todos</option>
+        {partidos.map(pOpt => (
+          <option key={pOpt} value={pOpt}>{pOpt}</option>
+        ))}
+      </FiltroSelect>
+      <FiltroLabel>Mês:</FiltroLabel>
+      <FiltroSelect value={mes} onChange={e => setMes(e.target.value)}>
+        <option value="">Todos</option>
+        {ano === String(currentYear)
+          ? [...Array(currentMonth)].map((_, i) => (
+              <option key={i+1} value={i+1}>{i+1}</option>
+            ))
+          : [...Array(12)].map((_, i) => (
+              <option key={i+1} value={i+1}>{i+1}</option>
+            ))}
+      </FiltroSelect>
+      <FiltroLabel>Ano:</FiltroLabel>
+      <FiltroSelect value={ano} onChange={e => setAno(e.target.value)}>
+        <option value="">Todos</option>
+        {Array.from({length: currentYear - 2022}, (_, i) => 2023 + i).map(y => (
+          <option key={y} value={y}>{y}</option>
+        ))}
+      </FiltroSelect>
+      <FiltroLabel>Ordem:</FiltroLabel>
+      <FiltroSelect value={ordem} onChange={e => setOrdem(e.target.value)}>
+        <option value="desc">Maior gasto</option>
+        <option value="asc">Menor gasto</option>
+      </FiltroSelect>
+    </Filtros>
+  );
+}

--- a/frontend/src/components/RankingFilters/index.spec.jsx
+++ b/frontend/src/components/RankingFilters/index.spec.jsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RankingFilters } from ".";
+
+describe("RankingFilters", () => {
+	const estados = ["PE", "SP", "RJ"];
+	const partidos = ["PSOL", "PT", "MDB"];
+	const defaultProps = {
+		limit: 20,
+		setLimit: jest.fn(),
+		uf: "",
+		setUf: jest.fn(),
+		partido: "",
+		setPartido: jest.fn(),
+		mes: "",
+		setMes: jest.fn(),
+		ano: "2025",
+		setAno: jest.fn(),
+		ordem: "desc",
+		setOrdem: jest.fn(),
+		estados,
+		partidos,
+	};
+
+	it("renderiza todos os filtros e opções iniciais", () => {
+		render(<RankingFilters {...defaultProps} />);
+			const selects = screen.getAllByRole("combobox");
+			expect(selects).toHaveLength(6);
+			// Limite, UF, Partido, Mês, Ano, Ordem
+			// Opções de UF
+			const ufSelect = selects[1];
+			estados.forEach(uf => {
+				expect(Array.from(ufSelect.options).map(o => o.value)).toContain(uf);
+			});
+			// Opções de Partido
+			const partidoSelect = selects[2];
+			partidos.forEach(p => {
+				expect(Array.from(partidoSelect.options).map(o => o.value)).toContain(p);
+			});
+	});
+
+	it("altera o limite ao selecionar outro valor", () => {
+		render(<RankingFilters {...defaultProps} />);
+		const selects = screen.getAllByRole("combobox");
+		fireEvent.change(selects[0], { target: { value: "30" } });
+		expect(defaultProps.setLimit).toHaveBeenCalledWith(30);
+	});
+
+	it("altera o UF ao selecionar outro valor", () => {
+		render(<RankingFilters {...defaultProps} />);
+		const selects = screen.getAllByRole("combobox");
+		fireEvent.change(selects[1], { target: { value: "SP" } });
+		expect(defaultProps.setUf).toHaveBeenCalledWith("SP");
+	});
+
+	it("altera o Partido ao selecionar outro valor", () => {
+		render(<RankingFilters {...defaultProps} />);
+		const selects = screen.getAllByRole("combobox");
+		fireEvent.change(selects[2], { target: { value: "PT" } });
+		expect(defaultProps.setPartido).toHaveBeenCalledWith("PT");
+	});
+
+	it("altera o Mês ao selecionar outro valor", () => {
+		render(<RankingFilters {...defaultProps} />);
+		const selects = screen.getAllByRole("combobox");
+		fireEvent.change(selects[3], { target: { value: "5" } });
+		expect(defaultProps.setMes).toHaveBeenCalledWith("5");
+	});
+
+	it("altera o Ano ao selecionar outro valor", () => {
+		render(<RankingFilters {...defaultProps} />);
+		const selects = screen.getAllByRole("combobox");
+		fireEvent.change(selects[4], { target: { value: "2024" } });
+		expect(defaultProps.setAno).toHaveBeenCalledWith("2024");
+	});
+
+	it("altera a Ordem ao selecionar outro valor", () => {
+		render(<RankingFilters {...defaultProps} />);
+		const selects = screen.getAllByRole("combobox");
+		fireEvent.change(selects[5], { target: { value: "asc" } });
+		expect(defaultProps.setOrdem).toHaveBeenCalledWith("asc");
+	});
+
+	it("renderiza meses corretos para o ano atual", () => {
+		// Simula ano atual e mês atual
+			const now = new Date();
+			const props = { ...defaultProps, ano: String(now.getFullYear()) };
+			render(<RankingFilters {...props} />);
+			const selects = screen.getAllByRole("combobox");
+			const mesSelect = selects[3];
+			const mesOptions = Array.from(mesSelect.options).map(opt => opt.value);
+			for (let i = 1; i <= now.getMonth() + 1; i++) {
+				expect(mesOptions).toContain(String(i));
+			}
+			expect(mesOptions).not.toContain("12");
+	});
+
+	it("renderiza 12 meses para anos anteriores", () => {
+			render(<RankingFilters {...defaultProps} ano="2024" />);
+			const selects = screen.getAllByRole("combobox");
+			const mesSelect = selects[3];
+			const mesOptions = Array.from(mesSelect.options).map(opt => opt.value);
+			for (let i = 1; i <= 12; i++) {
+				expect(mesOptions).toContain(String(i));
+			}
+	});
+});

--- a/frontend/src/components/RankingFilters/styles.js
+++ b/frontend/src/components/RankingFilters/styles.js
@@ -1,0 +1,31 @@
+import {styled} from "styled-components";
+
+export const Filtros = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 2rem;
+`;
+
+export const FiltroLabel = styled.label`
+  font-size: 1rem;
+  color: #555;
+  font-weight: 500;
+`;
+
+export const FiltroInput = styled.input`
+  padding: 0.3rem 0.7rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  font-size: 1rem;
+  min-width: 60px;
+`;
+
+export const FiltroSelect = styled.select`
+  padding: 0.3rem 0.7rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  font-size: 1rem;
+`;

--- a/frontend/src/components/RankingList/index.jsx
+++ b/frontend/src/components/RankingList/index.jsx
@@ -1,0 +1,25 @@
+import { GridDeputados, CardRanking, FotoArea, InfoArea, TotalArea } from "./styles";
+import { useNavigate } from "react-router-dom";
+
+export function RankingList({ deputados }) {
+    const navigate = useNavigate();
+    return (
+        <GridDeputados>
+            {deputados.length > 3 && deputados.slice(3).map((item, idx) => (
+            <CardRanking key={item.id || idx} onClick={() => navigate(`/deputados/${item.id}`)} role="button" tabIndex={0}>
+                <span style={{fontWeight:'bold', fontSize:'1.2rem', minWidth:32}}>{idx+4}º</span>
+                <FotoArea>
+                <img src={item.url_foto} alt={item.nome} />
+                </FotoArea>
+                <InfoArea>
+                <span style={{fontWeight:'bold'}}>{item.nome || "-"}</span>
+                <span style={{fontSize:'0.95rem', color:'#333'}}>{item.partido} - {item.uf}</span>
+                </InfoArea>
+                <TotalArea>
+                R$ {item.total_gasto?.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
+                </TotalArea>
+            </CardRanking>
+            ))}
+        </GridDeputados>
+  );
+}

--- a/frontend/src/components/RankingList/index.spec.js
+++ b/frontend/src/components/RankingList/index.spec.js
@@ -1,0 +1,102 @@
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+import { render, screen, fireEvent } from "@testing-library/react";
+// import { MemoryRouter } from "react-router-dom";
+import {RankingList} from "./index";
+
+const mockDeputados = [
+  {
+    id: 1,
+    nome: "Deputado Um",
+    partido: "ABC",
+    uf: "SP",
+    url_foto: "foto1.jpg",
+    total_gasto: 1234.56,
+  },
+  {
+    id: 2,
+    nome: "Deputado Dois",
+    partido: "DEF",
+    uf: "RJ",
+    url_foto: "foto2.jpg",
+    total_gasto: 2345.67,
+  },
+  {
+    id: 3,
+    nome: "Deputado Três",
+    partido: "GHI",
+    uf: "MG",
+    url_foto: "foto3.jpg",
+    total_gasto: 3456.78,
+  },
+  {
+    id: 4,
+    nome: "Deputado Quatro",
+    partido: "JKL",
+    uf: "RS",
+    url_foto: "foto4.jpg",
+    total_gasto: 4567.89,
+  },
+];
+
+describe("RankingList", () => {
+  it("não renderiza lista se houver 3 ou menos deputados", () => {
+    render(<RankingList deputados={mockDeputados.slice(0, 3)} />);
+    expect(screen.queryByText(/4º/)).not.toBeInTheDocument();
+  });
+
+  it("renderiza lista corretamente se houver mais de 3 deputados", () => {
+    render(<RankingList deputados={mockDeputados} />);
+    expect(screen.getByText("4º")).toBeInTheDocument();
+    expect(screen.getByText("Deputado Quatro")).toBeInTheDocument();
+    expect(screen.getByText("JKL - RS")).toBeInTheDocument();
+    expect(screen.getByText("R$ 4.567,89")).toBeInTheDocument();
+  });
+
+  it("navega para a página do deputado ao clicar no card", () => {
+    render(
+      <RankingList deputados={mockDeputados} />
+    );
+    const card = screen.getByText("4º").closest("div");
+    fireEvent.click(card);
+    expect(mockNavigate).toHaveBeenCalledWith("/deputados/4");
+  });
+
+  it("renderiza corretamente dados faltantes", () => {
+    const deputadosIncompletos = [
+      {
+        id: 5,
+        nome: "",
+        partido: "",
+        uf: "",
+        url_foto: "",
+        total_gasto: null,
+      },
+      {
+        id: 6,
+        nome: null,
+        partido: null,
+        uf: null,
+        url_foto: null,
+        total_gasto: undefined,
+      },
+      ...mockDeputados,
+    ];
+    render(
+      <RankingList deputados={deputadosIncompletos} />
+    );
+  // Busca o traço como substring em qualquer texto
+  const traço = screen.getAllByText((content) => content.includes('-'));
+  expect(traço.length).toBeGreaterThan(0);
+  });
+
+  it("não quebra se lista estiver vazia", () => {
+    render(
+  <RankingList deputados={[]} />
+    );
+    expect(screen.queryByText(/º/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RankingList/styles.js
+++ b/frontend/src/components/RankingList/styles.js
@@ -1,0 +1,65 @@
+
+import styled from "styled-components";
+
+export const GridDeputados = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 16px;
+`;
+
+
+export const CardRanking = styled.div`
+  display: flex;
+  align-items: center;
+  background: #f0f0f0;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  padding: 1rem;
+  min-height: 6rem;
+  gap: 1.5rem;
+  border: 1px solid #eee;
+  transition: 0.3s;
+
+  &:hover {
+    scale: 1.02;
+    filter: brightness(0.9);
+    cursor: pointer;
+  }
+
+  &:active {
+    scale: 0.95;
+    filter: brightness(1);
+  }
+`;
+
+export const FotoArea = styled.div`
+  height: 5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 6px;
+  }
+`;
+
+export const InfoArea = styled.div`
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+`;
+
+export const TotalArea = styled.div`
+  font-weight: bold;
+  font-size: 1.5rem;
+  color: #222;
+  margin-left: auto;
+`;
+
+
+
+

--- a/frontend/src/components/RankingPodio/index.jsx
+++ b/frontend/src/components/RankingPodio/index.jsx
@@ -1,0 +1,32 @@
+import { Podio, PodioItem } from "./styles";
+import { useNavigate } from "react-router-dom";
+
+const medalColors = [
+  '#FFD700', // ouro
+  '#C0C0C0', // prata
+  '#CD7F32'  // bronze
+];
+
+export function RankingPodio({ deputados }) {
+  const navigate = useNavigate();
+  return (
+    <Podio>
+      {deputados.slice(0,3).map((item, idx) => (
+        <PodioItem
+          key={item.id || idx}
+          style={{background: medalColors[idx], border: '2px solid ' + medalColors[idx]}}
+          $destaque
+          onClick={() => navigate(`/deputados/${item.id}`)}
+          role="button"
+          tabIndex={0}
+        >
+          <h4>{idx+1}º</h4>
+          <img src={item.url_foto} alt={item.nome} />
+          <span>{item.nome || "-"}</span>
+          <span>{item.partido} - {item.uf}</span>
+          <span>R$ {item.total_gasto?.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</span>
+        </PodioItem>
+      ))}
+    </Podio>
+  );
+}

--- a/frontend/src/components/RankingPodio/index.spec.jsx
+++ b/frontend/src/components/RankingPodio/index.spec.jsx
@@ -1,0 +1,98 @@
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RankingPodio } from ".";
+
+const mockDeputados = [
+  {
+    id: 1,
+    nome: "Deputado Ouro",
+    partido: "PSOL",
+    uf: "SP",
+    url_foto: "foto1.jpg",
+  },
+  {
+    id: 2,
+    nome: "Deputado Prata",
+    partido: "PSOL",
+    uf: "SP",
+    url_foto: "foto2.jpg",
+    total_gasto: 9637.52,
+  },
+  {
+    id: 3,
+    nome: "Deputado Bronze",
+    partido: "PSOL",
+    uf: "RJ",
+    url_foto: "foto3.jpg",
+    total_gasto: 10651.20,
+  },
+];
+
+describe("RankingPodio", () => {
+  it("renderiza os três primeiros deputados com medalhas e dados corretos", () => {
+    render(
+      <RankingPodio deputados={mockDeputados} />
+    );
+    expect(screen.getByText("1º")).toBeInTheDocument();
+    expect(screen.getByText("2º")).toBeInTheDocument();
+    expect(screen.getByText("3º")).toBeInTheDocument();
+    expect(screen.getByText("Deputado Ouro")).toBeInTheDocument();
+    expect(screen.getByText("Deputado Prata")).toBeInTheDocument();
+    expect(screen.getByText("Deputado Bronze")).toBeInTheDocument();
+    // Verifica que existem dois elementos "PSOL - SP" e um "PSOL - RJ"
+    const psolSpElements = screen.getAllByText("PSOL - SP");
+    expect(psolSpElements).toHaveLength(2);
+    const psolRjElements = screen.getAllByText("PSOL - RJ");
+    expect(psolRjElements).toHaveLength(1);
+    expect(screen.getByText("R$ 9.637,52")).toBeInTheDocument();
+    expect(screen.getByText("R$ 10.651,20")).toBeInTheDocument();
+  });
+
+  it("navega para a página do deputado ao clicar no card", () => {
+    render(
+      <RankingPodio deputados={mockDeputados} />
+    );
+  // Seleciona o PodioItem pelo texto do nome do deputado
+  const card = screen.getByText("Deputado Ouro").closest("div");
+  fireEvent.click(card);
+  expect(mockNavigate).toHaveBeenCalledWith("/deputados/1");
+  });
+
+  it("renderiza corretamente dados faltantes", () => {
+    const deputadosIncompletos = [
+      {
+        id: 4,
+        nome: "",
+        partido: "",
+        uf: "",
+        url_foto: "",
+        total_gasto: null,
+      },
+      {
+        id: 5,
+        nome: null,
+        partido: null,
+        uf: null,
+        url_foto: null,
+        total_gasto: undefined,
+      },
+      ...mockDeputados,
+    ];
+    render(
+      <RankingPodio deputados={deputadosIncompletos} />
+    );
+    expect(screen.getAllByText("-", { exact: false }).length).toBeGreaterThan(0);
+  });
+
+  it("não quebra se lista estiver vazia", () => {
+    render(
+        <RankingPodio deputados={[]} />
+    );
+    expect(screen.queryByText(/º/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RankingPodio/styles.js
+++ b/frontend/src/components/RankingPodio/styles.js
@@ -1,0 +1,41 @@
+import {styled} from "styled-components";
+
+export const Podio = styled.div`
+  display: flex;
+  gap: 2rem;
+  justify-content: center;
+  margin-bottom: 2rem;
+`;
+
+export const PodioItem = styled.div`
+  background: ${({ $destaque }) => $destaque ? '#fffbe6' : '#f0f0f0'};
+  border: ${({ $destaque }) => $destaque ? '2px solid #d4af37' : '1px solid #eee'};
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  padding: 1.2rem 2rem;
+  min-width: 16rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.1rem;
+  transition: 0.3s;
+
+  > img {
+    height: 8rem;
+    border-radius: 0.5rem;
+  }
+
+  &:hover {
+    scale: 1.05;
+    filter: brightness(0.9);
+    cursor: pointer;
+  }
+
+  &:active {
+    scale: 0.95;
+    filter: brightness(1);
+  }
+
+`;
+

--- a/frontend/src/hooks/useDeputadoReferencias.js
+++ b/frontend/src/hooks/useDeputadoReferencias.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+import { api } from "../services/api";
+import { toast } from "react-toastify";
+
+export function useDeputadoReferencias() {
+  const [estados, setEstados] = useState([]);
+  const [partidos, setPartidos] = useState([]);
+
+  useEffect(() => {
+    async function fetchReferencias() {
+      try {
+        const response = await api.get("/referencias/deputados");
+        setEstados(response.data.estados || []);
+        setPartidos(response.data.partidos || []);
+      } catch {
+        toast.error("Erro ao buscar referências de deputados");
+      }
+    }
+    fetchReferencias();
+  }, []);
+
+  return { estados, partidos };
+}

--- a/frontend/src/hooks/useDeputadoReferencias.spec.js
+++ b/frontend/src/hooks/useDeputadoReferencias.spec.js
@@ -1,0 +1,55 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useDeputadoReferencias } from './useDeputadoReferencias';
+import { toast } from 'react-toastify';
+
+jest.mock('../services/api', () => ({
+	api: {
+		get: jest.fn(),
+	},
+}));
+
+import {api} from '../services/api';
+
+jest.mock('react-toastify', () => ({
+	toast: { error: jest.fn() },
+}));
+
+describe('useDeputadoReferencias', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('retorna estados e partidos corretamente', async () => {
+		api.get.mockResolvedValueOnce({ data: { estados: ['SP', 'RJ'], partidos: ['PSOL', 'PT'] } });
+		const { result } = renderHook(() => useDeputadoReferencias());
+		await waitFor(() => expect(result.current.estados.length).toBeGreaterThan(0));
+		expect(result.current.estados).toEqual(['SP', 'RJ']);
+		expect(result.current.partidos).toEqual(['PSOL', 'PT']);
+	});
+
+	it('retorna arrays vazios se resposta não tem dados', async () => {
+		api.get.mockResolvedValueOnce({ data: {} });
+		const { result } = renderHook(() => useDeputadoReferencias());
+		await waitFor(() => expect(Array.isArray(result.current.estados)).toBe(true));
+		expect(result.current.estados).toEqual([]);
+		expect(result.current.partidos).toEqual([]);
+	});
+
+	it('chama toast.error em caso de erro', async () => {
+		api.get.mockRejectedValueOnce(new Error('fail'));
+		const { result } = renderHook(() => useDeputadoReferencias());
+		await waitFor(() => expect(toast.error).toHaveBeenCalled());
+		expect(toast.error).toHaveBeenCalledWith('Erro ao buscar referências de deputados');
+		expect(result.current.estados).toEqual([]);
+		expect(result.current.partidos).toEqual([]);
+	});
+
+	it('não faz múltiplas chamadas desnecessárias', async () => {
+		api.get.mockResolvedValue({ data: { estados: ['PE'], partidos: ['MDB'] } });
+		const { result } = renderHook(() => useDeputadoReferencias());
+		await waitFor(() => expect(result.current.estados.length).toBeGreaterThan(0));
+		expect(api.get).toHaveBeenCalledTimes(1);
+		expect(result.current.estados).toEqual(['PE']);
+		expect(result.current.partidos).toEqual(['MDB']);
+	});
+});

--- a/frontend/src/pages/Ranking/index.jsx
+++ b/frontend/src/pages/Ranking/index.jsx
@@ -1,0 +1,78 @@
+import { useState, useEffect } from "react";
+import { useDeputadoReferencias } from "../../hooks/useDeputadoReferencias";
+import { SideBar } from "../../components/SideBar";
+import { Container, Content, EmptyMessageContainer } from "./styles";
+import { RankingFilters } from "../../components/RankingFilters";
+import { RankingPodio } from "../../components/RankingPodio";
+import { RankingList } from "../../components/RankingList";
+import { api } from "../../services/api";
+import { toast } from "react-toastify";
+
+export function Ranking() {
+  const [deputados, setDeputados] = useState([]);
+  const [limit, setLimit] = useState(10);
+  const [uf, setUf] = useState("");
+  const [partido, setPartido] = useState("");
+  const [mes, setMes] = useState("");
+  const [ano, setAno] = useState("");
+  const [ordem, setOrdem] = useState("desc");
+  const { estados, partidos } = useDeputadoReferencias();
+
+  async function fetchRanking() {
+    try {
+      const params = {};
+      if (limit) params.limit = limit;
+      if (uf) params.uf = uf;
+      if (partido) params.partido = partido;
+      if (mes) params.mes = mes;
+      if (ano) params.ano = ano;
+      if (ordem) params.ordem = ordem;
+      const response = await api.get("/despesas/ranking", { params });
+      setDeputados(
+        Array.isArray(response.data.dados) ? response.data.dados : []
+      );
+    } catch {
+      toast.error("Erro ao buscar ranking de despesas");
+    }
+  }
+
+  useEffect(() => {
+    fetchRanking();
+    // eslint-disable-next-line
+  }, [limit, uf, partido, mes, ano, ordem]);
+
+  return (
+    <Container>
+      <SideBar />
+      <Content>
+        <h1>Ranking de Gastos</h1>
+        <RankingFilters
+          limit={limit}
+          setLimit={setLimit}
+          uf={uf}
+          setUf={setUf}
+          partido={partido}
+          setPartido={setPartido}
+          mes={mes}
+          setMes={setMes}
+          ano={ano}
+          setAno={setAno}
+          ordem={ordem}
+          setOrdem={setOrdem}
+          estados={estados}
+          partidos={partidos}
+        />
+        {deputados.length === 0 ? (
+          <EmptyMessageContainer>
+            <p style={{ fontSize: 22, color: '#666', textAlign: 'center' }}>Nenhum deputado encontrado.</p>
+          </EmptyMessageContainer>
+        ) : (
+          <>
+            <RankingPodio deputados={deputados} />
+            <RankingList deputados={deputados} />
+          </>
+        )}
+      </Content>
+    </Container>
+  );
+}

--- a/frontend/src/pages/Ranking/styles.js
+++ b/frontend/src/pages/Ranking/styles.js
@@ -1,0 +1,28 @@
+export const EmptyMessageContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  width: 100%;
+`;
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  height: 100vh;
+  background: white;
+`;
+
+export const Content = styled.div`
+  flex: 1;
+  padding: 2rem 3rem;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+
+  >h1 {
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+`;
+


### PR DESCRIPTION
## ✨ Pull Request: Implementa página de Ranking de Gastos Parlamentares com filtros e visualizações

### 📌 Descrição

Esta PR implementa a página de **Ranking de Gastos Parlamentares**, permitindo ao usuário visualizar os deputados com maiores gastos em um período, aplicar filtros por estado, partido e tipo de gasto, e destacar o pódio dos três primeiros colocados.

Inclui a criação de componentes para a lista, filtros e pódio, além de integração com o backend para busca dinâmica dos dados.

Closes #40 , Closes #41 

### ✅ Funcionalidades implementadas

* **Hook `useDeputadoReferencias`** – busca e fornece lista de partidos e estados para os filtros.
* **Componente `RankingFilters`** – filtros por estado, partido, tipo de gasto e período.
* **Componente `RankingList`** – exibe a lista ordenada dos deputados com maiores gastos.
* **Componente `RankingPodio`** – destaque visual para os três deputados mais bem colocados no ranking.
* **Página de Ranking** – integra filtros, lista e pódio em uma única visualização.
* Estilos dedicados para todos os componentes (`RankingFilters`, `CardRanking`, `Podio`).


### 🧪 Testes adicionados/atualizados

* Testes para o hook `useDeputadoReferencias`.
* Testes para `RankingFilters` validando funcionamento dos filtros e integração com dados.
* Testes para `RankingList` verificando renderização e ordenação correta.
* Testes para `RankingPodio` garantindo exibição correta dos três primeiros colocados.

### 📂 Branch

`feature/ranking`
